### PR TITLE
Basic contract reading

### DIFF
--- a/src/modules/nft/read-token/index.ts
+++ b/src/modules/nft/read-token/index.ts
@@ -9,6 +9,7 @@ import { rmrkAbi } from 'src/modules/nft/abi/rmrk';
 import { getContract, getGasLimit } from 'src/modules/nft/common-api';
 import { sanitizeIpfsUrl } from 'src/modules/nft/ipfs';
 import { IdBuilder } from 'src/modules/nft/rmrk-contract';
+import Contract from '../rmrk-contract/types/contracts/rmrk_contract';
 
 const PROOF_SIZE = 531_072;
 const REF_TIME = 9_480_453_976;
@@ -226,22 +227,13 @@ export const getEquippableChildren = async (
   await cryptoWaitReady();
 
   const abi = new Abi(rmrkAbi, api.registry.getChainProperties());
-  const contract = new ContractPromise(api, abi, contractAddress);
+  const contract = new Contract(contractAddress, senderAddress, api);
   if (!contract || contract === null) new Error('There is no contract found');
 
-  const initialGasLimit = contract.registry.createType('WeightV2', {
-    proofSize: PROOF_SIZE,
-    refTime: REF_TIME,
-  });
-
-  const children = await contract.query['nesting::getAcceptedChildren'](
-    senderAddress,
-    { gasLimit: initialGasLimit },
-    IdBuilder.U64(tokenId)
-  );
+  const children = await contract.query.getAcceptedChildren(IdBuilder.U64(tokenId));
   console.log('children', children);
   console.log('tokenId', tokenId);
-  console.log('contract.query', contract.query);
+  //console.log('contract.query', contract.query);
 
   // if (children.value) {
   //   for (let child of children.value) {

--- a/src/modules/nft/rmrk-contract/types/contracts/rmrk_contract.ts
+++ b/src/modules/nft/rmrk-contract/types/contracts/rmrk_contract.ts
@@ -14,12 +14,12 @@ import EventsClass from '../events/rmrk_contract';
 export default class Contract {
   readonly query: QueryMethods;
   readonly buildExtrinsic: BuildExtrinsicMethods;
-  readonly tx: TxSignAndSendMethods;
-  readonly methods: MixedMethods;
-  readonly events: EventsClass;
+  // readonly tx: TxSignAndSendMethods;
+  // readonly methods: MixedMethods;
+  // readonly events: EventsClass;
 
   readonly address: string;
-  readonly signer: KeyringPair;
+  // readonly signer: KeyringPair;
 
   private nativeContract: ContractPromise;
   private nativeAPI: ApiPromise;
@@ -32,18 +32,18 @@ export default class Contract {
 	 * @param signer - The signer to use for signing transactions.
 	 * @param nativeAPI - The API instance to use for queries.
 	*/
-  constructor(address: string, signer: KeyringPair, nativeAPI: ApiPromise) {
+  constructor(address: string, signerAddress: string, nativeAPI: ApiPromise) {
     this.address = address;
     this.nativeContract = new ContractPromise(nativeAPI, ABI, address);
     this.nativeAPI = nativeAPI;
-    this.signer = signer;
+    // this.signer = signer;
     this.contractAbi = new Abi(ABI);
 
-    this.query = new QueryMethods(this.nativeContract, this.nativeAPI, signer.address);
+    this.query = new QueryMethods(this.nativeContract, this.nativeAPI, signerAddress);
     this.buildExtrinsic = new BuildExtrinsicMethods(this.nativeContract, this.nativeAPI);
-    this.tx = new TxSignAndSendMethods(nativeAPI, this.nativeContract, signer);
-    this.methods = new MixedMethods(nativeAPI, this.nativeContract, signer);
-    this.events = new EventsClass(this.nativeContract, nativeAPI);
+    // this.tx = new TxSignAndSendMethods(nativeAPI, this.nativeContract, signer);
+    // this.methods = new MixedMethods(nativeAPI, this.nativeContract, signer);
+    // this.events = new EventsClass(this.nativeContract, nativeAPI);
   }
 
   /**
@@ -76,9 +76,9 @@ export default class Contract {
    * await contract.withSigner(signerBob).transfer(signerAlice.address, 100);
    * ```
    */
-  withSigner(signer: KeyringPair): Contract {
-    return new Contract(this.address, signer, this.nativeAPI);
-  }
+  // withSigner(signer: KeyringPair): Contract {
+  //   return new Contract(this.address, signer, this.nativeAPI);
+  // }
 
   /**
    * withAddress
@@ -86,9 +86,9 @@ export default class Contract {
    * @param address - The address of the contract.
    * @returns New instance of the contract class to interact with new contract.
    */
-  withAddress(address: string): Contract {
-    return new Contract(address, this.signer, this.nativeAPI);
-  }
+  // withAddress(address: string): Contract {
+  //   return new Contract(address, this.signer, this.nativeAPI);
+  // }
 
   /**
    * withAPI
@@ -96,7 +96,7 @@ export default class Contract {
    * @param api - The API instance to use for queries.
    * @returns New instance of the contract class to interact with new API.
    */
-  withAPI(api: ApiPromise): Contract {
-    return new Contract(this.address, this.signer, api);
-  }
+  // withAPI(api: ApiPromise): Contract {
+  //   return new Contract(this.address, this.signer, api);
+  // }
 }

--- a/src/modules/nft/rmrk-contract/types/shared/utils.ts
+++ b/src/modules/nft/rmrk-contract/types/shared/utils.ts
@@ -1,14 +1,16 @@
-import fs from 'fs';
+/* eslint-disable @typescript-eslint/no-var-requires */
 import type { ContractPromise } from '@polkadot/api-contract';
 import { handleEventReturn } from '@727-ventures/typechain-types';
 
 export function getTypeDescription(id: number | string, fileName: string): any {
-  const types = JSON.parse(fs.readFileSync(__dirname + `/../data/${fileName}.json`, 'utf8'));
+  // const types = JSON.parse(fs.readFileSync(__dirname + `/../data/${fileName}.json`, 'utf8'));
+  const types = require('../data/rmrk_contract.json');
   return types[id];
 }
 
 export function getEventTypeDescription(name: string, fileName: string): any {
-  const types = JSON.parse(fs.readFileSync(__dirname + `/../event-data/${fileName}.json`, 'utf8'));
+  // const types = JSON.parse(fs.readFileSync(__dirname + `/../event-data/${fileName}.json`, 'utf8'));
+  const types = require('../event-data/rmrk_contract.json');
   return types[name];
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "esModuleInterop": true,
     "experimentalDecorators": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "resolveJsonModule": true,
   }
 }


### PR DESCRIPTION
Tweaked generated code to ignore signer until we figure out how to pass wallet signer to contract constructor. This is not ideal because we are dealing with auto generated code and every code re-generation will override our changes, but it will server purpose for some time.

ATM contract supports only data read. For transactions ContractPromise can be used.